### PR TITLE
DM-Possessed Spellcasting

### DIFF
--- a/src/scripts/tb_inc_spells.nss
+++ b/src/scripts/tb_inc_spells.nss
@@ -884,12 +884,12 @@ void spellDumpInfo(object oCaster, struct spell_st spellInfo, int nSpellID) {
 int checkSpellComponents(int nSpellID, object oCaster) {
 
         //not a PC
-    if(!GetIsPC(oCaster)) {
+    if (!GetIsPC(oCaster)) {
         return TRUE;
     }
 
     // is a DM?
-    if(GetIsDM(oCaster)) {
+    if (GetIsDM(oCaster) || GetIsDMPossessed(oCaster)) {
         return TRUE;
     }
 


### PR DESCRIPTION
DM-possessed NPCs will no longer trigger the check for spell components, as NPCs already don't.