### PR TITLE
Paladins, Ankhegs & Cantrips

### DIFF
--- a/src/scripts/tb_inc_spells.nss
+++ b/src/scripts/tb_inc_spells.nss
@@ -902,6 +902,12 @@ int checkSpellComponents(int nSpellID, object oCaster) {
     int nClass = GetLastSpellCastClass();
     int nCastLevel = GetCasterLevel(OBJECT_SELF);
 
+    // Cantrips never need components
+    if (SFGetInnateSpellLevelByClass(nSpellID, nClass) == 0)
+    {
+        return TRUE;
+    }
+
     //int nNonHostile = GetIsNonHostileSpell(nSpell);
     //object sTarget = GetSpellTargetObject();
     //object oArea = GetArea(oCaster);

--- a/src/scripts/te_bountyhandle.nss
+++ b/src/scripts/te_bountyhandle.nss
@@ -22,21 +22,32 @@ void TE_DeathHandle(object oDead, object oKiller)
 
     if(GetLevelByClass(CLASS_TYPE_PALADIN,oKiller) >= 1 && GetLevelByClass(CLASS_TYPE_BLACKGUARD,oKiller) < 1 && GetLevelByClass(51,oKiller) < 1)
     {
-        if(GetRacialType(oDead) != RACIAL_TYPE_CONSTRUCT &&
-        GetRacialType(oDead) != RACIAL_TYPE_VERMIN &&
-        GetRacialType(oDead) != RACIAL_TYPE_DRAGON &&
-        GetRacialType(oDead) != RACIAL_TYPE_UNDEAD)
+        int nType = GetRacialType(oDead)
+
+        if(nType != RACIAL_TYPE_UNDEAD &&
+        nType != RACIAL_TYPE_ANIMAL &&
+        nType != RACIAL_TYPE_VERMIN &&
+        nType != RACIAL_TYPE_MAGICAL_BEAST &&
+        nType != RACIAL_TYPE_BEAST &&
+        nType != RACIAL_TYPE_OOZE &&
+        nType != RACIAL_TYPE_ABERRATION &&
+        nType != RACIAL_TYPE_CONSTRUCT &&
+        nType != RACIAL_TYPE_ELEMENTAL &&
+        nType != RACIAL_TYPE_DRAGON)
         {
             if(GetAlignmentGoodEvil(oDead) == ALIGNMENT_NEUTRAL)
             {
                 SetLocalInt(oItem,"nPiety",nPiety-10);
                 AdjustAlignment(oKiller,ALIGNMENT_CHAOTIC,5,FALSE);
+                SendMessageToPC(oKiller,"This unnecessary bloodshed tarnishes you in the eyes of your deity.");
             }
             else if(GetAlignmentGoodEvil(oDead) == ALIGNMENT_GOOD)
             {
                 SetLocalInt(oItem,"nPiety",0);
+                SetLocalInt(oItem,"iTrans",1);
                 AdjustAlignment(oKiller,ALIGNMENT_EVIL,25,FALSE);
                 AdjustAlignment(oKiller,ALIGNMENT_CHAOTIC,25,FALSE);
+                SendMessageToPC(oKiller,"The murder of a righteous person weighs heavily on your soul. You have fallen from the grace of your deity.");
             }
         }
     }
@@ -44,7 +55,9 @@ void TE_DeathHandle(object oDead, object oKiller)
     {
         if(nPiety >= 50)
         {
-            if(GetRacialType(oDead) == RACIAL_TYPE_UNDEAD || GetRacialType(oDead) == RACIAL_TYPE_OUTSIDER)
+            int nType = GetRacialType(oDead)
+
+            if(nType == RACIAL_TYPE_UNDEAD || nType == RACIAL_TYPE_OUTSIDER)
             {
                 SetLocalInt(oItem,"nPiety",nPiety+2);
             }


### PR DESCRIPTION
- Cantrips no longer require material components. This affects Daze (wool), Resistance (miniature cloak) and Light (phosphorescent moss). This is a stopgap measure that just auto-passes the check for level 0 spells, because the actual component requirements are in a 2DA.
- Paladins no longer receive penalties for killing non-Evil animals, beasts, magical beasts, oozes, aberrations, or elementals (many of whom cannot comprehend moral philosophy)
- Paladins get a feedback message when their alignment shifts and piety decreases due to killing the wrong creature
- Paladins falling for killing Good NPCs is now consistent. Previously, they would fall but the flag wouldn't trigger until they next tried to cast a spell. This is a stopgap measure prior to discussing doing away with this kind of stuff entirely.