### PR TITLE
Fixed -11 death bug

### DIFF
--- a/src/scripts/loi_ondeath.nss
+++ b/src/scripts/loi_ondeath.nss
@@ -179,7 +179,6 @@ void main()
                         int nHeal = -6;   //should heal the player to -5 so that bleed script will take over
                         ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nHeal), oPC);
                     }
-                    return;
                 }
 
                 NWNX_WebHook_SendWebHookHTTPS("discordapp.com", WEBHOOK_CHAT_CHANNEL, sJoinMsg, GetName(oPC));


### PR DESCRIPTION
Fixed issue causing players to not get sent to death area when they die. 

Removed "return" added in previous commit Siobhan mythic #28 I'm pretty sure it was added accidentally. 

Tested locally, standard death functionality works as it should again. 
Probably ok to hotfix it in if you want.